### PR TITLE
Add libevent dependency in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ There is currently no binary distribution of ReFlex. You will therefore need  to
 2. Install library dependencies: 
 
    ```
-   sudo apt-get install libconfig-dev libnuma-dev libpciaccess-dev libaio-dev
+   sudo apt-get install libconfig-dev libnuma-dev libpciaccess-dev libaio-dev libevent-dev
    ```
 
 3. Build the dependecies:


### PR DESCRIPTION
Add a missing dependency in the readme. If missing, reflex cannot link with error:
```console
/usr/bin/ld: cannot find -levent
```